### PR TITLE
[release] 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.1.1
+
+#### Major changes
+
+- Add `foreman` gem, along with `start:development` and `start:production` tasks (via `rake`) for running development and production builds with `Procfile`s. ([#3](https://github.com/eonu/react-rails-api/pull/3))
+- Make the top-level CLI command display help specifically for the `react-rails new` command. ([#4](https://github.com/eonu/react-rails-api/pull/4))
+- Hide the CLI `version`, `--version`, `-v` command from the help interface. ([#4](https://github.com/eonu/react-rails-api/pull/4))
+
+#### Minor changes
+
+- Change API scope parameter to a symbol: `'/api'` -> `:api`. ([#1](https://github.com/eonu/react-rails-api/pull/1))
+- Add `rake` task descriptions for running development and production builds. [[`README.md`](https://github.com/eonu/react-rails-api/pull/2/files#diff-04c6e90faac2675aa89e2176d2eec7d8)] ([#2](https://github.com/eonu/react-rails-api/pull/2))
+- Add Charlie Gleason's medium article as a reference. [[`README.md`](https://github.com/eonu/react-rails-api/pull/2/files#diff-04c6e90faac2675aa89e2176d2eec7d8)] ([#2](https://github.com/eonu/react-rails-api/pull/2))
+
 # 0.1.0
 
 #### Major changes

--- a/lib/react-rails-api/version.rb
+++ b/lib/react-rails-api/version.rb
@@ -2,7 +2,7 @@ module ReactRailsAPI
   VERSION = {
     major: 0,
     minor: 1,
-    patch: 0,
+    patch: 1,
     meta: nil
   }.values.reject(&:nil?).map(&:to_s)*?.
 end


### PR DESCRIPTION
# Major changes

- Add `foreman` gem, along with `start:development` and `start:production` tasks (via `rake`) for running development and production builds with `Procfile`s. ([#3](https://github.com/eonu/react-rails-api/pull/3))
- Make the top-level CLI command display help specifically for the `react-rails new` command. ([#4](https://github.com/eonu/react-rails-api/pull/4))
- Hide the CLI `version`, `--version`, `-v` command from the help interface. ([#4](https://github.com/eonu/react-rails-api/pull/4))

# Minor changes

- Change API scope parameter to a symbol: `'/api'` -> `:api`. ([#1](https://github.com/eonu/react-rails-api/pull/1))
- Add `rake` task descriptions for running development and production builds. [[`README.md`](https://github.com/eonu/react-rails-api/pull/2/files#diff-04c6e90faac2675aa89e2176d2eec7d8)] ([#2](https://github.com/eonu/react-rails-api/pull/2))
- Add Charlie Gleason's medium article as a reference. [[`README.md`](https://github.com/eonu/react-rails-api/pull/2/files#diff-04c6e90faac2675aa89e2176d2eec7d8)] ([#2](https://github.com/eonu/react-rails-api/pull/2))