### PR TITLE
[release] 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.2
+
+#### Major changes
+
+- Force top-level `package.json` to be overwritten if it already exists. ([#7](https://github.com/eonu/react-rails-api/pull/7))
+
+#### Minor changes
+
+- Remove Charlie Gleason as an author (in Gemspec). ([#8](https://github.com/eonu/react-rails-api/pull/8))
+
 # 0.1.1
 
 #### Major changes

--- a/lib/react-rails-api/version.rb
+++ b/lib/react-rails-api/version.rb
@@ -2,7 +2,7 @@ module ReactRailsAPI
   VERSION = {
     major: 0,
     minor: 1,
-    patch: 1,
+    patch: 2,
     meta: nil
   }.values.reject(&:nil?).map(&:to_s)*?.
 end


### PR DESCRIPTION
# Major changes

- Force top-level `package.json` to be overwritten if it already exists. ([#7](https://github.com/eonu/react-rails-api/pull/7))

# Minor changes

- Remove Charlie Gleason as an author (in Gemspec). ([#8](https://github.com/eonu/react-rails-api/pull/8))